### PR TITLE
Fix index limit errors (well most of them...)

### DIFF
--- a/app/models/payload_adapters/github_push.rb
+++ b/app/models/payload_adapters/github_push.rb
@@ -26,6 +26,7 @@ module PayloadAdapters
 
       @payload.delete("commits")
       @payload.delete("head_commit")
+      @payload.delete("repository")
 
       # Tally the committers
       @payload["committers"] = @payload["committers"].inject(Hash.new) do |totals, committer|


### PR DESCRIPTION
(Reissue of #21)

For quite a while now, we've been getting errors from Postgres on github events as the size of the payload was bigger than the limit for PG indices:

```
An ActiveRecord::StatementInvalid occurred in events#create:

  PG::ProgramLimitExceeded: ERROR:  index row size 3872 exceeds maximum 2712 for index "events_gin_data"
: INSERT INTO "events" ("created_at", "data", "kinship_id", "metric_id", "updated_at", "user_id") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"
  app/controllers/api/events_controller.rb:10:in `create'
```

Looking at the latest payloads in the db, it seems the biggest useless part is the `repository`:

```
irb(main):027:0> pp Event.last(10).map{ |e| [e.metric.nameata.keys.map{|k| [k, d[k].to_s.size]} ] }
[["github_pull_request_comment",
  [["issue", 2315],
   ["metric", 27],
   ["sender", 903],
   ["comment", 1698],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_push",
  [["ref", 0],
   ["after", 0],
   ["before", 0],
   ["forced", 0],
   ["metric", 27],
   ["pusher", 0],
   ["sender", 903],
   ["compare", 0],
   ["created", 0],
   ["deleted", 0],
   ["base_ref", 0],
   ["committers", 0],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_pull_request_comment",
  [["issue", 2315],
   ["metric", 27],
   ["sender", 903],
   ["comment", 1698],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_pull_request_comment",
  [["issue", 2315],
   ["metric", 27],
   ["sender", 903],
   ["comment", 1698],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_push",
  [["ref", 0],
   ["after", 0],
   ["before", 0],
   ["forced", 0],
   ["metric", 27],
   ["pusher", 0],
   ["sender", 903],
   ["compare", 0],
   ["created", 0],
   ["deleted", 0],
   ["base_ref", 0],
   ["committers", 0],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_pull_request_comment",
  [["issue", 2315],
   ["metric", 27],
   ["sender", 903],
   ["comment", 1698],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_push",
  [["ref", 0],
   ["after", 0],
   ["before", 0],
   ["forced", 0],
   ["metric", 27],
   ["pusher", 0],
   ["sender", 903],
   ["compare", 0],
   ["created", 0],
   ["deleted", 0],
   ["base_ref", 0],
   ["committers", 0],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_push",
  [["ref", 0],
   ["after", 0],
   ["before", 0],
   ["forced", 0],
   ["metric", 27],
   ["pusher", 0],
   ["sender", 903],
   ["compare", 0],
   ["created", 0],
   ["deleted", 0],
   ["base_ref", 0],
   ["committers", 0],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_push",
  [["ref", 0],
   ["after", 0],
   ["before", 0],
   ["forced", 0],
   ["metric", 27],
   ["pusher", 0],
   ["sender", 903],
   ["compare", 0],
   ["created", 0],
   ["deleted", 0],
   ["base_ref", 0],
   ["committers", 0],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]],
 ["github_pull_request_comment",
  [["issue", 2315],
   ["metric", 27],
   ["sender", 903],
   ["comment", 1698],
   ["repository", 4727],
   ["issue_action", 0],
   ["organization", 433],
   ["request_ip_address", 13]]]]
```

Let's just remove it.

cc @elseano @lukearndt 