### PR TITLE
Migrate from mandrill to sendgrid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,6 +96,8 @@ Highlander::Application.configure do
     :user_name => ENV["SMTP_USERNAME"],
     :password => ENV["SMTP_PASSWORD"],
     :domain => ENV["SMTP_HELO_DOMAIN"],
+    :authentication => :plain,
+    :enable_starttls_auto => true,
   }
 
   # config.cache_store = :dalli_store, ENV["MEMCACHIER_SERVERS"],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,7 +94,8 @@ Highlander::Application.configure do
     :address => ENV["SMTP_HOST"],
     :port => ENV["SMTP_PORT"],
     :user_name => ENV["SMTP_USERNAME"],
-    :password => ENV["SMTP_PASSWORD"]
+    :password => ENV["SMTP_PASSWORD"],
+    :domain => ENV["SMTP_HELO_DOMAIN"],
   }
 
   # config.cache_store = :dalli_store, ENV["MEMCACHIER_SERVERS"],


### PR DESCRIPTION
Small SMTP config tweaks to allow migrating from Mandrill to Sendgrid.